### PR TITLE
Bump org.apache.commons:commons-lang3 from 3.14.0 to 3.15.0 (#47)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.14.0</version>
+			<version>3.15.0</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
Bumps org.apache.commons:commons-lang3 from 3.14.0 to 3.15.0.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-lang3 dependency-type: direct:production update-type: version-update:semver-minor ...